### PR TITLE
Added strip shell script to xCode project in the post build process

### DIFF
--- a/Plugin/CleverTapUnity/Editor/CleverTapPostBuildProcessor.cs
+++ b/Plugin/CleverTapUnity/Editor/CleverTapPostBuildProcessor.cs
@@ -72,9 +72,16 @@ public static class CleverTapPostBuildProcessor
 			proj.AddFrameworkToProject(projectTarget, "CoreLocation.framework", false);
 			proj.AddFrameworkToProject(projectTarget, "Security.framework", false);
 
-            // Add linker flags
-            proj.AddBuildProperty(projectTarget, "OTHER_LDFLAGS", "-ObjC");
+			// Add linker flags
+			proj.AddBuildProperty(projectTarget, "OTHER_LDFLAGS", "-ObjC");
 
+#if UNITY_2018_3_OR_NEWER
+			using (var streamReader = new StreamReader(@"Assets/CleverTapUnity/iOS/strip.sh", Encoding.UTF8))
+			{
+				proj.AddShellScriptBuildPhase(projectTarget, "Build Frameworks", "/bin/sh", streamReader.ReadToEnd());
+			}
+#endif
+			
 			File.WriteAllText(projPath, proj.WriteToString());
 
 			// Update plist

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 
     ![alt text](example/images/push_entitle.jpg  "push notifications capability")
 
+##### Pre Unity Editor v2018.3
+If you are on a newer Unity version than 2018.3 this step is done automatically during the post build process. 
+
 - Add a run script to your build phases, In Xcode, go to your Targets, under your app’s name, select Build Phases after   embed frameworks, add a run script phase and set it to use `/bin/sh` and the [script found here](https://github.com/CleverTap/clevertap-unity-sdk/blob/master/Plugin/CleverTapUnity/iOS/strip.sh):
 
   ![alt text](example/images/ct_script_ios.jpg  "run script")


### PR DESCRIPTION
Added the manual step for striping the unnecessary simulator architectures to the post build process. This allows for automated build pipelines such as Unity Cloud Services, but also reduces the steps require through manual builds too.

Before these changes, Unity Cloud build will fail with:
```
error: exportArchive: IPA processing failed
Error Domain=IDEFoundationErrorDomain Code=1 "IPA processing failed" UserInfo={NSLocalizedDescription=IPA processing failed}
```

After these changes,  Unity Cloud build will succeed with:
```
Running script 'Build Frameworks'
publishing finished successfully.
```